### PR TITLE
Use native colours in prompt

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -83,8 +83,8 @@ function fish_prompt
   _print_in_color "\n"(_pwd_with_tilde) blue
 
   if _in_git_directory
-    _print_in_color " "(_git_branch_name_or_revision) 242
-    _print_in_color " "(_git_status) FCBC47
+    _print_in_color " "(_git_branch_name_or_revision) green
+    _print_in_color " "(_git_status) yellow
     _print_in_color " "(_git_upstream_status) cyan
   end
 


### PR DESCRIPTION
Use [fish-native colours](https://fishshell.com/docs/current/commands.html#set_color) to ensure that the prompt colours match the terminal theme.